### PR TITLE
updated membership bot for orders

### DIFF
--- a/MembershipBot/MembershipBot.py
+++ b/MembershipBot/MembershipBot.py
@@ -277,6 +277,8 @@ def get_spreadsheet(spreadsheet_title):
     except SpreadsheetNotFound:
         handler = client.create(spreadsheet_title)
 
+    print("Sheet '%s' available at: %s" % (spreadsheet_title, handler.url))
+
     return handler
 
 def update_spreadsheet(spreadsheet, worksheet_title, header_row, rows_to_add):
@@ -294,7 +296,6 @@ def update_spreadsheet(spreadsheet, worksheet_title, header_row, rows_to_add):
     if not target_sheet:
         target_sheet = spreadsheet.add_worksheet(title=worksheet_title, rows=1, cols=len(rows_to_add[0]))
 
-
     target_sheet.clear()
     target_sheet.resize(rows=1)
     target_sheet.append_row(header_row, value_input_option='USER-ENTERED', table_range='A1:B1')
@@ -309,8 +310,7 @@ def update_customer_db(database, member_list):
 
     return 0
 
-def sync_memberships(orders_in_json):
-    year = datetime.now().year
+def sync_memberships(orders_in_json, year):
 
     spreadsheet_title = "SYC - Year %s" % year
     worksheet_title = 'Memberships'
@@ -358,8 +358,7 @@ def sync_memberships(orders_in_json):
 
     return 0
 
-def sync_moorings(orders_in_json):
-    year = datetime.now().year
+def sync_moorings(orders_in_json, year):
 
     spreadsheet_title = "SYC - Year %s" % year
     worksheet_title = 'Moorings'
@@ -397,7 +396,6 @@ def sync_moorings(orders_in_json):
     gs = get_spreadsheet(spreadsheet_title)
 
     # update the google sheet
-    # check for column 1 for non-duplicate entries
     try:
         update_spreadsheet(gs, worksheet_title, spreadsheet_header, formatted_orders)
     except Exception as e:
@@ -406,8 +404,7 @@ def sync_moorings(orders_in_json):
 
     return 0
 
-def sync_lessons(orders_in_json):
-    year = datetime.now().year
+def sync_lessons(orders_in_json, year):
 
     spreadsheet_title = "SYC - Year %s" % year
     worksheet_title = 'Lessons'
@@ -417,8 +414,7 @@ def sync_lessons(orders_in_json):
 
     return 0
 
-def sync_orders(orders_in_json):
-    year = datetime.now().year
+def sync_orders(orders_in_json, year):
 
     spreadsheet_title = 'SYC Orders'
     worksheet_title = "Year %s" % year
@@ -479,12 +475,18 @@ def main():
         return 1
 
     orders_api_endpoint = "https://api.squarespace.com/1.0/commerce/orders"
-    beginning_of_year = date(datetime.today().year, 1, 1).isoformat()+ 'T00:00:00.0Z'
+
+    year = datetime.now().year
+    # Process the current year by default. Uncomment below and comment above to get information for previous years
+    #year = 2021
+
+    year_beginning = date(year, 1, 1).isoformat()+ 'T00:00:00.0Z'
+    year_end = date(year, 12, 30).isoformat()+ 'T00:00:00.0Z'
 
     # define JSON parameters for the date range to get orders
     request_parameters = {
-        "modifiedAfter": beginning_of_year,
-        "modifiedBefore": datetime.now().isoformat() + 'Z',
+        "modifiedAfter": year_beginning,
+        "modifiedBefore": year_end,
     }
 
     # Initiate the call to get_orders which will iterate on pagination
@@ -500,13 +502,13 @@ def main():
         return 1
 
     # Sync orders
-    sync_orders(orders_in_json)
+    sync_orders(orders_in_json, year)
 
     # Sync memberships
-    sync_memberships(orders_in_json)
+    sync_memberships(orders_in_json, year)
 
     # Sync moorings
-    sync_moorings(orders_in_json)
+    sync_moorings(orders_in_json, year)
 
     return 0
 

--- a/MembershipBot/MembershipBot.py
+++ b/MembershipBot/MembershipBot.py
@@ -492,7 +492,7 @@ def main():
         orders_in_json = get_orders(orders_api_endpoint, request_parameters)
 
         if not orders_in_json:
-            print("No new members since %s day(s) ago" % scheduled_sync_days)
+            print("No new orders since the beginning of the year")
             return 0
 
     except requests.exceptions.HTTPError as error:

--- a/MembershipBot/MembershipBot.py
+++ b/MembershipBot/MembershipBot.py
@@ -114,7 +114,7 @@ spreadsheet_header_orders = [
 
 ## function to get a nested list of all orders from squarespace
 ## returns: dictionary of orders from json result
-def get_orders(orders_api_endpoint, parameters):
+def get_items(api_endpoint, parameters):
     order_list = []
     commerce_creds = os.environ.get('SQUARESPACE_API_KEY')
 
@@ -124,7 +124,7 @@ def get_orders(orders_api_endpoint, parameters):
         "User-Agent": "MembershipBot"
     }
 
-    response = requests.get(orders_api_endpoint, headers=headers, params=parameters)
+    response = requests.get(api_endpoint, headers=headers, params=parameters)
     if response.raise_for_status():
         pass
     else:
@@ -135,7 +135,7 @@ def get_orders(orders_api_endpoint, parameters):
             order_list.append(member)
 
         if json_data['pagination']['hasNextPage']:
-            return (order_list + get_orders(json_data['pagination']['nextPageUrl'], None))
+            return (order_list + get_items(json_data['pagination']['nextPageUrl'], None))
     else:
         print("Return status was NOT OK: %s" % response.status_code)
         return False
@@ -489,9 +489,9 @@ def main():
         "modifiedBefore": year_end,
     }
 
-    # Initiate the call to get_orders which will iterate on pagination
+    # Initiate the call to get_items which will iterate on pagination
     try:
-        orders_in_json = get_orders(orders_api_endpoint, request_parameters)
+        orders_in_json = get_items(orders_api_endpoint, request_parameters)
 
         if not orders_in_json:
             print("No new orders since the beginning of the year")

--- a/MembershipBot/MembershipBot.py
+++ b/MembershipBot/MembershipBot.py
@@ -89,6 +89,7 @@ spreadsheet_header_orders = [
                         'Secondary Email',
                         'Membership Type',
                         'Renewal Type',
+                        'Fulfillment',
                         'Price',
                         'Discount',
                         'Home Address',
@@ -192,6 +193,7 @@ def parse_orders(unparsed_orders, filter_types):
         parsed_order['home_address'] = street_address + ", " + member['billingAddress']['city'] + ", " + member['billingAddress']['state'] + " " + member['billingAddress']['postalCode']
 
         parsed_order['year'] = parsedate.isoparse(member['modifiedOn']).year
+        parsed_order['fulfillment'] = member['fulfillmentStatus']
         parsed_order['price_paid'] = member['grandTotal']['value']
         parsed_order['price_discount'] = member['discountTotal']['value']
 
@@ -433,6 +435,7 @@ def sync_orders(orders_in_json):
                             order['secondary_email'],
                             order['membership_type'],
                             order['renewal'],
+                            order['fulfillment'],
                             order['price_paid'],
                             order['price_discount'],
                             order['home_address'],
@@ -482,7 +485,6 @@ def main():
     request_parameters = {
         "modifiedAfter": beginning_of_year,
         "modifiedBefore": datetime.now().isoformat() + 'Z',
-        "fulfillmentStatus": "FULFILLED"
     }
 
     # Initiate the call to get_orders which will iterate on pagination

--- a/MembershipBot/MembershipBot.py
+++ b/MembershipBot/MembershipBot.py
@@ -512,6 +512,9 @@ def main():
 
     return 0
 
+def handler(event, context):
+    return main()
+
 if __name__ == "__main__":
     return_val = 1
     try:

--- a/MembershipBot/MembershipBot.py
+++ b/MembershipBot/MembershipBot.py
@@ -16,10 +16,6 @@ filter_type_members = [
                         'Individual Membership',
                         'Emeritus Membership',
                         'Junior Membership',
-                        '2022 Family Membership',
-                        '2022 Partner Membership',
-                        '2022 Individual Membership',
-                        '2022 Junior Membership',
                     ]
 
 filter_type_moorings = [
@@ -201,7 +197,8 @@ def parse_orders(unparsed_orders, filter_types):
 
         for line_item in member['lineItems']:
             # Check if they bought a membership
-            if line_item['productName'] in filter_type_members:
+            # Year may be updated, check to see if suffix matches a member filter type
+            if line_item['productName'].endswith(tuple(filter_type_members)):
                 parsed_order['membership_type'] = line_item['productName']
 
                 if line_item['customizations']:
@@ -254,7 +251,7 @@ def parse_orders(unparsed_orders, filter_types):
             if line_item['productName'] in filter_type_mooring_svcs:
                 parsed_order['mooring_svcs'] = 'yes'
 
-            if line_item['productName'] in filter_types:
+            if line_item['productName'].endswith(tuple(filter_types)):
                 add_member_to_list = True
 
         if add_member_to_list:
@@ -320,7 +317,7 @@ def sync_memberships(orders_in_json):
     formatted_orders = []
     parsed_orders = parse_orders(orders_in_json, filter_type_members)
     for order in parsed_orders:
-        formatted_order = [ 
+        formatted_order = [
                             order['order_no'],
                             order['name'],
                             order['email'],

--- a/MembershipBot/MembershipBot.py
+++ b/MembershipBot/MembershipBot.py
@@ -1,20 +1,124 @@
 #!/usr/bin/env python3
 
-
-# importing the required libraries
 import os
 import sys
 import gspread
-import json
+from gspread.exceptions import *
 import requests
 #from importlib import reload
 from oauth2client.service_account import ServiceAccountCredentials
 from datetime import date, datetime, timedelta
+from dateutil import parser as parsedate
 
-## function to get a nested list of all member data to be written
-## function is recursive to iterate through multiple json pages
-def get_members(orders_api_endpoint, parameters):
-    member_list = []
+filter_type_members = [
+                        'Family Membership',
+                        'Partner Membership',
+                        'Individual Membership',
+                        'Emeritus Membership',
+                        'Junior Membership',
+                        '2022 Family Membership',
+                        '2022 Partner Membership',
+                        '2022 Individual Membership',
+                        '2022 Junior Membership',
+                    ]
+
+filter_type_moorings = [
+                        'Shoreline',
+                        'Water-Row A',
+                        'Water-Row B',
+                        'Water-Row C',
+                        'Water-Row D',
+                        'Water-Row E',
+                        'Water-Row F',
+                        'Water-Row H',
+                        'Water-Row I',
+                    ]
+
+filter_type_mooring_svcs = [
+                        'Mooring Services',
+                        ]
+
+filter_type_moorings_all = filter_type_moorings + filter_type_mooring_svcs
+
+filter_type_lessons = [
+                        'Sailing Morning',
+                        'Sailing Afternoon',
+                    ]
+
+filter_type_orders = filter_type_members + filter_type_moorings
+
+spreadsheet_header_members = [
+                        'Order No',
+                        'Primary Name',
+                        'Primary Email',
+                        'Secondary Name',
+                        'Secondary Email',
+                        'Membership Type',
+                        'Renewal Type',
+                        'Home Address',
+                        'Cell Phone',
+                        'Emergency Contact',
+                        'Emergency Phone',
+                        'Child #1 Name',
+                        'Child #1 DOB',
+                        'Child #2 Name',
+                        'Child #2 DOB',
+                        'Child #3 Name',
+                        'Child #3 DOB',
+                        'Child #4 Name',
+                        'Child #4 DOB',
+                    ]
+
+spreadsheet_header_moorings = [
+                        'Order No',
+                        'Name',
+                        'Email',
+                        'Mooring Location',
+                        'Mooring Color',
+                        'Boat Type',
+                        'Boat Color',
+                        'Town Permit No',
+                    ]
+
+spreadsheet_header_lessons = [
+                        'Order No',
+                        'Created On',
+                    ]
+
+spreadsheet_header_orders = [
+                        'Order No',
+                        'Primary Name',
+                        'Primary Email',
+                        'Secondary Name',
+                        'Secondary Email',
+                        'Membership Type',
+                        'Renewal Type',
+                        'Price',
+                        'Discount',
+                        'Home Address',
+                        'Cell Phone',
+                        'Emergency Contact',
+                        'Emergency Phone',
+                        'Child #1 Name',
+                        'Child #1 DOB',
+                        'Child #2 Name',
+                        'Child #2 DOB',
+                        'Child #3 Name',
+                        'Child #3 DOB',
+                        'Child #4 Name',
+                        'Child #4 DOB',
+                        'Mooring Location',
+                        'Mooring Color',
+                        'Boat Type',
+                        'Boat Color',
+                        'Town Permit No',
+                        'Mooring Services',
+                    ]
+
+## function to get a nested list of all orders from squarespace
+## returns: dictionary of orders from json result
+def get_orders(orders_api_endpoint, parameters):
+    order_list = []
     commerce_creds = os.environ.get('SQUARESPACE_API_KEY')
 
     # define JSON headers, API key pulled from environment variable SQUARESPACE_API_KEY
@@ -31,122 +135,134 @@ def get_members(orders_api_endpoint, parameters):
 
     if response.status_code == requests.codes.ok:
         for member in json_data['result']:
-            member_list.append(member)
+            order_list.append(member)
 
         if json_data['pagination']['hasNextPage']:
-            return (member_list + get_members(json_data['pagination']['nextPageUrl'], None))
+            return (order_list + get_orders(json_data['pagination']['nextPageUrl'], None))
     else:
         print("Return status was NOT OK: %s" % response.status_code)
         return False
 
-    return member_list
+    return order_list
 
-def parse_members(unparsed_members):
-    parsed_memberlist = []
-
-    # create a list of types of memberships
-    member_types_list = [   "Family Membership",
-                            "Partner Membership",
-                            "Individual Membership",
-                            "Emeritus Membership",
-                            "Junior Membership",
-                            "2022 Family Membership",
-                            "2022 Partner Membership",
-                            "2022 Individual Membership",
-                            "2022 Junior Membership",
-                        ]
-
-    row_types_list =    [   "Water-Row A",
-                            "Water-Row B",
-                            "Water-Row C",
-                            "Water-Row D",
-                            "Water-Row E",
-                            "Water-Row F",
-                            "Water-Row H",
-                            "Water-Row I",
-                        ]
+def parse_orders(unparsed_orders, filter_types):
+    parsed_orderlist = []
 
     # iterate through every lineItem, which corresponds to an order in the system
     # we further select by only finding orders which correspond to memberships
-    for member in unparsed_members:
-        parsed_member = {}
+    for member in unparsed_orders:
+        parsed_order = {    'order_no': '',
+                            'name': '',
+                            'email': '',
+                            'secondary_name': '',
+                            'secondary_email': '',
+                            'membership_type': '',
+                            'renewal': '',
+                            'price_paid': '',
+                            'price_discount': '',
+                            'home_address': '',
+                            'cell_phone': '',
+                            'emergency_contact_name': '',
+                            'emergency_contact_phone': '',
+                            'child_member_1_name': '',
+                            'child_member_1_dob': '',
+                            'child_member_2_name': '',
+                            'child_member_2_dob': '',
+                            'child_member_3_name': '',
+                            'child_member_3_dob': '',
+                            'child_member_4_name': '',
+                            'child_member_4_dob': '',
+                            'mooring_location': '',
+                            'mooring_color': '',
+                            'boat_type': '',
+                            'boat_color': '',
+                            'town_permit_no': '',
+                            'mooring_svcs': 'no',
+                            'year': '',
+                        }
 
-        parsed_member['name'] = member['billingAddress']['firstName'] + " " + member['billingAddress']['lastName']
-        parsed_member['email'] = member['customerEmail']
-        parsed_member['street_address'] = member['billingAddress']['address1']
-        parsed_member['city'] = member['billingAddress']['city']
-        parsed_member['state'] = member['billingAddress']['state']
-        parsed_member['zipcode'] = member['billingAddress']['postalCode']
-        parsed_member['created_on'] = member['createdOn']
-        parsed_member['fulfilled'] = member['fulfillmentStatus']
-        parsed_member['price_paid'] = member['grandTotal']['value']
-        parsed_member['discount_price'] = member['discountTotal']['value']
+        add_member_to_list = False
+
+        parsed_order['order_no'] = member['orderNumber']
+        parsed_order['name'] = member['billingAddress']['firstName'] + " " + member['billingAddress']['lastName']
+        parsed_order['email'] = member['customerEmail']
+
+        # Figure out the home address
+        try:
+            street_address = member['billingAddress']['address1'] + " " + member['billingAddress']['address2']
+        except TypeError:
+            street_address = member['billingAddress']['address1']
+
+        parsed_order['home_address'] = street_address + ", " + member['billingAddress']['city'] + ", " + member['billingAddress']['state'] + " " + member['billingAddress']['postalCode']
+
+        parsed_order['year'] = parsedate.isoparse(member['modifiedOn']).year
+        parsed_order['price_paid'] = member['grandTotal']['value']
+        parsed_order['price_discount'] = member['discountTotal']['value']
 
         for line_item in member['lineItems']:
             # Check if they bought a membership
-            if line_item['productName'] in member_types_list:
-                parsed_member['membership_type'] = line_item['productName']
+            if line_item['productName'] in filter_type_members:
+                parsed_order['membership_type'] = line_item['productName']
 
                 if line_item['customizations']:
                     for index, customization in enumerate(line_item['customizations']):
                         for item in customization:
                             if customization['label'] == 'Confirm Membership Type':
-                                parsed_member['renewal'] = customization['value']
-                            elif customization['label'] == 'Primary Member Name':
-                                parsed_member['primary_member'] = customization['value']
+                                parsed_order['renewal'] = customization['value']
                             elif customization['label'] == 'Cell Phone':
-                                parsed_member['cell_phone'] = customization['value'].strip()
+                                parsed_order['cell_phone'] = customization['value'].strip()
                             elif customization['label'] == 'Primary Address':
-                                parsed_member['home_address'] = customization['value']
+                                parsed_order['home_address'] = customization['value']
                             elif customization['label'] == 'Secondary Member Name':
-                                parsed_member['secondary_member'] = customization['value']
+                                parsed_order['secondary_name'] = customization['value']
                             elif customization['label'] == 'Secondary Member Email':
-                                parsed_member['secondary_email'] = customization['value']
+                                parsed_order['secondary_email'] = customization['value']
                             elif customization['label'] == 'Emergency Contact Name':
-                                parsed_member['emergency_contact_name'] = customization['value']
+                                parsed_order['emergency_contact_name'] = customization['value']
                             elif customization['label'] == 'Emergency Contact Phone':
-                                parsed_member['emergency_contact_phone'] = customization['value'].strip()
+                                parsed_order['emergency_contact_phone'] = customization['value'].strip()
                             elif (customization['label'] == 'Child Family Member #1'):
-                                parsed_member['child_member_1'] = {}
-                                parsed_member['child_member_1']['name'] = line_item['customizations'][index][item]
-                                parsed_member['child_member_1']['dob'] = line_item['customizations'][index+1][item]
+                                parsed_order['child_member_1_name'] = line_item['customizations'][index][item]
+                                parsed_order['child_member_1_dob'] = line_item['customizations'][index+1][item]
                             elif (customization['label'] == 'Child Family Member #2'):
-                                parsed_member['child_member_2'] = {}
-                                parsed_member['child_member_2']['name'] = line_item['customizations'][index][item]
-                                parsed_member['child_member_2']['dob'] = line_item['customizations'][index+1][item]
+                                parsed_order['child_member_2_name'] = line_item['customizations'][index][item]
+                                parsed_order['child_member_2_dob'] = line_item['customizations'][index+1][item]
                             elif (customization['label'] == 'Child Family Member #3'):
-                                parsed_member['child_member_3'] = {}
-                                parsed_member['child_member_3']['name'] = line_item['customizations'][index][item]
-                                parsed_member['child_member_3']['dob'] = line_item['customizations'][index+1][item]
+                                parsed_order['child_member_3_name'] = line_item['customizations'][index][item]
+                                parsed_order['child_member_3_dob'] = line_item['customizations'][index+1][item]
                             elif (customization['label'] == 'Child Family Member #4'):
-                                parsed_member['child_member_4'] = {}
-                                parsed_member['child_member_4']['name'] = line_item['customizations'][index][item]
-                                parsed_member['child_member_4']['dob'] = line_item['customizations'][index+1][item]
+                                parsed_order['child_member_4_name'] = line_item['customizations'][index][item]
+                                parsed_order['child_member_4_dob'] = line_item['customizations'][index+1][item]
+
             # Check if they bought a mooring
-            if line_item['productName'] in row_types_list:
-                parsed_member['boat_registration'] = {}
-                parsed_member['boat_registration']['mooring'] = line_item['productName']
-                parsed_member['boat_registration']['mooring_color'] = line_item['variantOptions'][0]['value']
+            if line_item['productName'] in filter_type_moorings:
+                parsed_order['mooring_location'] = line_item['productName']
+
+                if line_item['variantOptions']:
+                    parsed_order['mooring_color'] = line_item['variantOptions'][0]['value']
 
                 if line_item['customizations']:
                     for index, customization in enumerate(line_item['customizations']):
                         for item in customization:
                             if customization['label'] == 'Type of Boat':
-                                parsed_member['boat_registration']['type_of_boat'] = customization['value']
+                                parsed_order['boat_type'] = customization['value']
                             elif customization['label'] == 'Boat Color':
-                                parsed_member['boat_registration']['boat_color'] = customization['value']
+                                parsed_order['boat_color'] = customization['value']
                             elif customization['label'] == 'Town Boat Permit #':
-                                parsed_member['boat_registration']['town_permit_no'] = customization['value']
+                                parsed_order['town_permit_no'] = customization['value']
 
-            # Check if they added mooring services
-            if line_item['productName'] == 'Mooring Services':
-                parsed_member['mooring_svcs'] = True
+            if line_item['productName'] in filter_type_mooring_svcs:
+                parsed_order['mooring_svcs'] = 'yes'
 
-        parsed_memberlist.append(parsed_member)
+            if line_item['productName'] in filter_types:
+                add_member_to_list = True
 
-    return parsed_memberlist
+        if add_member_to_list:
+            parsed_orderlist.append(parsed_order)
 
-def get_spreadsheet(spreadsheet_name):
+    return parsed_orderlist
+
+def get_spreadsheet(spreadsheet_title):
     # define the scope
     scope = ['https://spreadsheets.google.com/feeds','https://www.googleapis.com/auth/drive']
 
@@ -157,145 +273,248 @@ def get_spreadsheet(spreadsheet_name):
     client = gspread.authorize(credentials)
 
     # get the instance of the Spreadsheet
-    return client.open(spreadsheet_name)
+    try:
+        handler = client.open(spreadsheet_title)
+    except SpreadsheetNotFound:
+        handler = client.create(spreadsheet_title)
 
-def update_spreadsheet(spreadsheet, member_list):
+    return handler
+
+def update_spreadsheet(spreadsheet, worksheet_title, header_row, rows_to_add):
 
     # make a spreadsheet for the year if necessary
     # set the target_sheet for the sheet we'll be writing to
     worksheets = spreadsheet.worksheets()
 
     target_sheet = None
-    current_year = date.today().year
-
     for sheet in worksheets:
-        if sheet.title == "Year %s" % current_year:
+        if sheet.title == worksheet_title:
             target_sheet = sheet
 
     # If sheet was not found create it
     if not target_sheet:
-        target_sheet = spreadsheet.add_worksheet(title="Year %s" % current_year, rows=1, cols=30)
-        target_sheet.append_row([   'Primary Name',
-                                    'Primary Email',
-                                    'Secondary Name',
-                                    'Secondary Email',
-                                    'Membership Type',
-                                    'Renewal Type',
-                                    'Price',
-                                    'Discount',
-                                    'Home Address',
-                                    'Cell Phone',
-                                    'Emergency Contact',
-                                    'Emergency Phone',
-                                    'Child #1 Name',
-                                    'Child #1 DOB',
-                                    'Child #2 Name',
-                                    'Child #2 DOB',
-                                    'Child #3 Name',
-                                    'Child #3 DOB',
-                                    'Child #4 Name',
-                                    'Child #4 DOB',
-                                    'Mooring Location',
-                                    'Mooring Color',
-                                    'Mooring Services',
-                                    'Boat Type',
-                                    'Boat Color',
-                                    'Permit No',
-                                ], value_input_option='USER-ENTERED', table_range='A1:B1')
+        target_sheet = spreadsheet.add_worksheet(title=worksheet_title, rows=1, cols=len(rows_to_add[0]))
 
-    # write to the google doc
-    start_row = target_sheet.row_count + 1
 
-    new_members = []
-    for person in member_list:
-        formatted_person = [    person['name'],
-                                person['email'],
-                                person['secondary_member'] if 'secondary_member' in person.keys() else '',
-                                person['secondary_email'] if 'secondary_email' in person.keys() else '',
-                                person['membership_type']if 'membership_type' in person.keys() else '',
-                                person['renewal'] if 'renewal' in person.keys() else '',
-                                person['price_paid'] if 'price_paid' in person.keys() else '',
-                                person['discount_price'] if 'discount_price' in person.keys() else '',
-                                person['home_address'] if 'home_address' in person.keys() else '',
-                                person['cell_phone'] if 'cell_phone' in person.keys() else '',
-                                person['emergency_contact_name'] if 'emergency_contact_name' in person.keys() else '',
-                                person['emergency_contact_phone'] if 'emergency_contact_phone' in person.keys() else '',
-                                person['child_member_1']['name'] if 'child_member_1' in person.keys() else '',
-                                person['child_member_1']['dob'] if 'child_member_1' in person.keys() else '',
-                                person['child_member_2']['name'] if 'child_member_2' in person.keys() else '',
-                                person['child_member_2']['dob'] if 'child_member_2' in person.keys() else '',
-                                person['child_member_3']['name'] if 'child_member_3' in person.keys() else '',
-                                person['child_member_3']['dob'] if 'child_member_3' in person.keys() else '',
-                                person['child_member_4']['name'] if 'child_member_4' in person.keys() else '',
-                                person['child_member_4']['dob'] if 'child_member_4' in person.keys() else '',
-                                person['boat_registration']['mooring'] if 'boat_registration' in person.keys() else '',
-                                person['boat_registration']['mooring_color'] if 'boat_registration' in person.keys() else '',
-                                person['mooring_svcs'] if 'mooring_svcs' in person.keys() else '',
-                                person['boat_registration']['type_of_boat'] if 'boat_registration' in person.keys() else '',
-                                person['boat_registration']['boat_color'] if 'boat_registration' in person.keys() else '',
-                                person['boat_registration']['town_permit_no'] if 'boat_registration' in person.keys() else '',
-                            ]
+    target_sheet.clear()
+    target_sheet.resize(rows=1)
+    target_sheet.append_row(header_row, value_input_option='USER-ENTERED', table_range='A1:B1')
 
-        new_members.append(formatted_person)
-
-    target_sheet.append_rows(new_members, value_input_option='USER-ENTERED', table_range='A{}'.format(start_row))
-    target_sheet.columns_auto_resize(0, 30)
+    start_row = 1
+    target_sheet.append_rows(rows_to_add, value_input_option='USER-ENTERED', table_range='A{}'.format(start_row))
+    target_sheet.columns_auto_resize(0, len(rows_to_add[0]))
 
     return True
 
 def update_customer_db(database, member_list):
 
-    return
+    return 0
 
-## main code begin ##
+def sync_memberships(orders_in_json):
+    year = datetime.now().year
 
-def handler(event, context):
-    # definte variables
-    orders_api_endpoint = "https://api.squarespace.com/1.0/commerce/orders"
-    scheduled_sync_days = 1
-    syc_spreadsheet = 'Brent Testing'
+    spreadsheet_title = "SYC - Year %s" % year
+    worksheet_title = 'Memberships'
+    spreadsheet_header = spreadsheet_header_members
 
+    formatted_orders = []
+    parsed_orders = parse_orders(orders_in_json, filter_type_members)
+    for order in parsed_orders:
+        formatted_order = [ 
+                            order['order_no'],
+                            order['name'],
+                            order['email'],
+                            order['secondary_name'],
+                            order['secondary_email'],
+                            order['membership_type'],
+                            order['renewal'],
+                            order['home_address'],
+                            order['cell_phone'],
+                            order['emergency_contact_name'],
+                            order['emergency_contact_phone'],
+                            order['child_member_1_name'],
+                            order['child_member_1_dob'],
+                            order['child_member_2_name'],
+                            order['child_member_2_dob'],
+                            order['child_member_3_name'],
+                            order['child_member_3_dob'],
+                            order['child_member_4_name'],
+                            order['child_member_4_dob'],
+                            ]
+        formatted_orders.append(formatted_order)
+
+    if not formatted_orders:
+        return 0
+
+    # get the spreadsheet handler
+    gs = get_spreadsheet(spreadsheet_title)
+
+    # update the google sheet
+    # check for column 1 for non-duplicate entries
+    try:
+        update_spreadsheet(gs, worksheet_title, spreadsheet_header, formatted_orders)
+    except Exception as e:
+        print("failure updating google sheets: %s" % e)
+        return 1
+
+    return 0
+
+def sync_moorings(orders_in_json):
+    year = datetime.now().year
+
+    spreadsheet_title = "SYC - Year %s" % year
+    worksheet_title = 'Moorings'
+    spreadsheet_header = spreadsheet_header_moorings
+
+    formatted_orders = []
+    parsed_orders = parse_orders(orders_in_json, filter_type_moorings_all)
+    for order in parsed_orders:
+        formatted_order = [
+                            order['order_no'],
+                            order['name'],
+                            order['email'],
+                            order['mooring_location'],
+                            order['mooring_color'],
+                            order['boat_type'],
+                            order['boat_color'],
+                            order['town_permit_no'],
+                            order['mooring_svcs'],
+                            ]
+
+        if order['mooring_location'] != '':
+            formatted_orders.append(formatted_order)
+
+    for unformatted_order in parsed_orders:
+        if ((unformatted_order['mooring_location'] == '') and (unformatted_order['mooring_svcs'] == 'yes')):
+            # Loop through the formatted orders list and update for mooring services
+            for formatted_order in formatted_orders:
+                if unformatted_order['email'] == formatted_order[2]:
+                    formatted_order[8] = 'yes'
+
+    if not formatted_orders:
+        return 0
+
+    # get the spreadsheet handler
+    gs = get_spreadsheet(spreadsheet_title)
+
+    # update the google sheet
+    # check for column 1 for non-duplicate entries
+    try:
+        update_spreadsheet(gs, worksheet_title, spreadsheet_header, formatted_orders)
+    except Exception as e:
+        print("failure updating google sheets: %s" % e)
+        return 1
+
+    return 0
+
+def sync_lessons(orders_in_json):
+    year = datetime.now().year
+
+    spreadsheet_title = "SYC - Year %s" % year
+    worksheet_title = 'Lessons'
+    spreadsheet_header = spreadsheet_header_lessons
+
+    # TODO: Add poll/webhook for sailing lessons
+
+    return 0
+
+def sync_orders(orders_in_json):
+    year = datetime.now().year
+
+    spreadsheet_title = 'SYC Orders'
+    worksheet_title = "Year %s" % year
+    spreadsheet_header = spreadsheet_header_orders
+
+    formatted_orders = []
+    parsed_orders = parse_orders(orders_in_json, filter_type_orders)
+    for order in parsed_orders:
+        formatted_order = [
+                            order['order_no'],
+                            order['name'],
+                            order['email'],
+                            order['secondary_name'],
+                            order['secondary_email'],
+                            order['membership_type'],
+                            order['renewal'],
+                            order['price_paid'],
+                            order['price_discount'],
+                            order['home_address'],
+                            order['cell_phone'],
+                            order['emergency_contact_name'],
+                            order['emergency_contact_phone'],
+                            order['child_member_1_name'],
+                            order['child_member_1_dob'],
+                            order['child_member_2_name'],
+                            order['child_member_2_dob'],
+                            order['child_member_3_name'],
+                            order['child_member_3_dob'],
+                            order['child_member_4_name'],
+                            order['child_member_4_dob'],
+                            order['mooring_location'],
+                            order['mooring_color'],
+                            order['boat_type'],
+                            order['boat_color'],
+                            order['town_permit_no'],
+                            order['mooring_svcs'],
+                            ]
+        formatted_orders.append(formatted_order)
+
+    # get the spreadsheet handler
+    gs = get_spreadsheet(spreadsheet_title)
+
+    # update the google sheet
+    # check for column 1 for non-duplicate entries
+    try:
+        update_spreadsheet(gs, worksheet_title, spreadsheet_header, formatted_orders)
+    except Exception as e:
+        print("failure updating google sheets: %s" % e)
+        return 1
+
+    return 0
+
+def main():
     # Added tests for environment variables
     if os.environ.get('SQUARESPACE_API_KEY') is None:
         print("Failed to pass SQUARESPACE_API_KEY")
         return 1
 
-    # define JSON parameters
-    parameters = {
-        "modifiedAfter": (datetime.now() - timedelta(days=scheduled_sync_days)).isoformat() + 'Z',
+    orders_api_endpoint = "https://api.squarespace.com/1.0/commerce/orders"
+    beginning_of_year = date(datetime.today().year, 1, 1).isoformat()+ 'T00:00:00.0Z'
+
+    # define JSON parameters for the date range to get orders
+    request_parameters = {
+        "modifiedAfter": beginning_of_year,
         "modifiedBefore": datetime.now().isoformat() + 'Z',
         "fulfillmentStatus": "FULFILLED"
     }
 
-    # Initiate the call to get_members which will iterate on pagination
+    # Initiate the call to get_orders which will iterate on pagination
     try:
-        raw_members = get_members(orders_api_endpoint, parameters)
+        orders_in_json = get_orders(orders_api_endpoint, request_parameters)
+
+        if not orders_in_json:
+            print("No new members since %s day(s) ago" % scheduled_sync_days)
+            return 0
+
     except requests.exceptions.HTTPError as error:
         print("Failed to get new members: %s" % error)
         return 1
 
-    if raw_members:
-        scrubbed_members = parse_members(raw_members)
-    else:
-        print("No new members since %s day(s) ago" % scheduled_sync_days)
-        return 0
+    # Sync orders
+    sync_orders(orders_in_json)
 
-    # get the spreadsheet handler
-    gs = get_spreadsheet(syc_spreadsheet)
+    # Sync memberships
+    sync_memberships(orders_in_json)
 
-    ## write new_members to google sheet ##
-    try:
-        update_spreadsheet(gs, scrubbed_members)
-    except Exception as e:
-        print("Failure updating Google Sheets: %s" % e)
-        return 1
+    # Sync moorings
+    sync_moorings(orders_in_json)
 
     return 0
 
 if __name__ == "__main__":
     return_val = 1
     try:
-        return_val = handler(None, None)
+        return_val = main()
     except KeyboardInterrupt:
         print("Caught a control-C. Bailing out")
 


### PR DESCRIPTION
Another big update. Updates will get smaller from here on out.

Basic details:
* All orders are pulled from Jan 1st, spreadsheet is recreated everytime it's run
* Recreating the spreadsheet was easier than reconciling orders for things like mooring services that happened after the initial transaction
* There are two different spreadsheets created, one for orders and one for the dock
* The spreadsheet for the dock has two tabs, one for memberships and one for moorings
* TODO items are to add sailing lesson schedules into the spreadsheet